### PR TITLE
Format without flicker, move cursor to line causing error on format

### DIFF
--- a/ElixirFormatter.py
+++ b/ElixirFormatter.py
@@ -3,22 +3,42 @@ import sublime
 import sublime_plugin
 import subprocess
 import threading
+import re
+
+SYNTAX_ERROR_RE = re.compile(
+    r"^\*\*\s\((.+)\)\s(.+)\:(\d+)\:\s(.+)$",
+    re.MULTILINE | re.IGNORECASE | re.UNICODE)
+PLUGIN_NAME = "ElixirFormatter"
 
 class ElixirFormatter:
     @staticmethod
-    def run(file_name):
+    def run(view, edit, file_name):
         project_root_with_mix = ElixirFormatter.find_project(file_name)
         project_root = project_root_with_mix or os.path.dirname(file_name)
         file_name_rel = file_name.replace(project_root + "/", "")
         blacklisted = ElixirFormatter.check_blacklisted_in_config(project_root, file_name_rel)
         if blacklisted:
-            print("ElixirFormatter skipped '{0}' due to :inputs key in '.formatter.exs'".
-              format(file_name_rel))
+            print("{0} skipped '{1}' due to :inputs key in '.formatter.exs'".
+              format(PLUGIN_NAME, file_name_rel))
             return
 
-        stdout, stderr = ElixirFormatter.run_command(project_root, ["mix", "format", file_name_rel])
-        if stderr != "":
-            print("ElixirFormatter catched error running 'mix format':\n{0}".format(stderr))
+        region = sublime.Region(0, view.size())
+        source_text = view.substr(region)
+        result = ElixirFormatter.mix_format(source_text, project_root)
+        if result.is_successful:
+            if result.is_equal(source_text):
+                print("{0} found no formatting is needed: files are equal".
+              format(PLUGIN_NAME, file_name_rel))
+                return
+            previous_position = view.viewport_position()
+            Utils.replace(view, edit, region, result.pretty_text)
+            Utils.indent(view)
+            Utils.restore_position(view, previous_position)
+            Utils.st_status_message("file formatted")
+        else:
+            print("{0}: {1}".format(PLUGIN_NAME, result.error.full_message))
+            view.run_command("goto_line", {"line": result.error.line})
+            Utils.st_status_message(result.error.status_message)
 
     @staticmethod
     def find_project(cwd = None):
@@ -31,7 +51,7 @@ class ElixirFormatter:
             return ElixirFormatter.find_project(os.path.dirname(cwd))
 
     @staticmethod
-    def run_command(project_root, task_args):
+    def mix_format(source_text, project_root):
         settings = sublime.load_settings('Preferences.sublime-settings')
         env = os.environ.copy()
 
@@ -41,26 +61,29 @@ class ElixirFormatter:
             pass
 
         if sublime.platform() == "windows":
-            launcher = ['cmd', '/c']
+            launcher = ["mix.bat", "format", "-"]
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         else:
-            launcher = []
+            launcher = ["mix", "format", "-"]
             startupinfo = None
 
         process = subprocess.Popen(
-            launcher + task_args,
+            launcher,
             cwd = project_root,
             env = env,
+            stdin = subprocess.PIPE,
             stdout = subprocess.PIPE,
             stderr = subprocess.PIPE,
             startupinfo = startupinfo)
 
-        stdout, stderr = process.communicate()
+        binary_source = bytes(source_text, "utf-8")
+        stdout, stderr = process.communicate(input = binary_source)
         stdout = stdout.decode('utf-8')
         stderr = stderr.decode('utf-8')
+        exit_code = process.returncode
 
-        return [stdout, stderr]
+        return MixFormatResult(stdout, stderr, exit_code)
 
     check_blacklisted_script_template = """
       file = \"[[file]]\"
@@ -87,9 +110,87 @@ class ElixirFormatterFormatFileCommand(sublime_plugin.TextCommand):
         extension = os.path.splitext(file_name)[1][1:]
         syntax = self.view.settings().get("syntax")
         if extension in ["ex", "exs"] or "Elixir" in syntax:
-            threading.Thread(target=ElixirFormatter.run, args=(file_name,)).start()
+            ElixirFormatter.run(self.view, edit, file_name)
 
 class ElixirFormatterEventListeners(sublime_plugin.EventListener):
     @staticmethod
-    def on_post_save(view):
+    def on_pre_save(view):
         view.run_command("elixir_formatter_format_file")
+
+class MixFormatError:
+    def __init__(self, text):
+        self.text = text
+        self.__matches = SYNTAX_ERROR_RE.search(text)
+
+    @property
+    def full_message(self):
+        return self.__matches.group(0)
+
+    @property
+    def exception(self):
+        return self.__matches.group(1)
+
+    @property
+    def line(self):
+        return int(self.__matches.group(3))
+
+    @property
+    def reason(self):
+        return self.__matches.group(4)
+
+    @property
+    def status_message(self):
+        return "{0} - {1}".format(self.exception, self.reason)
+
+class MixFormatResult:
+    def __init__(self, stdout, stderr, exit_code):
+        self.__stdout = stdout
+        self.__stderr = stderr
+        self.__exit_code = exit_code
+        self.__error = None
+        if not self.is_successful:
+            self.__error = MixFormatError(self.__stderr)
+
+    @property
+    def is_successful(self):
+        return self.__exit_code == 0
+
+    @property
+    def error(self):
+        return self.__error
+
+    def is_changed(self, source_text):
+        trimmed_pretty = Utils.trim_trailing_ws_and_lines(self.pretty_text)
+        trimmed_source = Utils.trim_trailing_ws_and_lines(source_text)
+        return trimmed_source != source_text and trimmed_source != trimmed_pretty
+
+    def is_equal(self, text):
+        return not self.is_changed(text)
+
+    @property
+    def pretty_text(self):
+        return self.__stdout
+
+class Utils:
+    @staticmethod
+    def trim_trailing_ws_and_lines(val):
+        if val is None:
+            return val
+        val = re.sub(r'\s+\Z', '', val)
+        return val
+
+    @staticmethod
+    def indent(view):
+        view.run_command('detect_indentation')
+
+    @staticmethod
+    def restore_position(view, previous_position):
+        view.set_viewport_position((0, 0), False)
+        view.set_viewport_position(previous_position, False)
+
+    @staticmethod
+    def replace(view, edit, region, text):
+        view.replace(edit, region, text)
+
+    def st_status_message(msg):
+        sublime.set_timeout(lambda: sublime.status_message('{0}: {1}'.format(PLUGIN_NAME, msg)), 0)

--- a/ElixirFormatter.py
+++ b/ElixirFormatter.py
@@ -9,6 +9,7 @@ SYNTAX_ERROR_RE = re.compile(
     r"^\*\*\s\((.+)\)\s(.+)\:(\d+)\:\s(.+)$",
     re.MULTILINE | re.IGNORECASE | re.UNICODE)
 PLUGIN_NAME = "ElixirFormatter"
+PLUGIN_CMD_NAME = "elixir_formatter_format_file"
 
 class ElixirFormatter:
     @staticmethod
@@ -115,7 +116,7 @@ class ElixirFormatterFormatFileCommand(sublime_plugin.TextCommand):
 class ElixirFormatterEventListeners(sublime_plugin.EventListener):
     @staticmethod
     def on_pre_save(view):
-        view.run_command("elixir_formatter_format_file")
+        view.run_command(PLUGIN_CMD_NAME)
 
 class MixFormatError:
     def __init__(self, text):
@@ -192,5 +193,6 @@ class Utils:
     def replace(view, edit, region, text):
         view.replace(edit, region, text)
 
+    @staticmethod
     def st_status_message(msg):
         sublime.set_timeout(lambda: sublime.status_message('{0}: {1}'.format(PLUGIN_NAME, msg)), 0)

--- a/testfile.ex
+++ b/testfile.ex
@@ -1,0 +1,95 @@
+defmodule Flow.MapReducer do
+  @moduledoc false
+  use GenStage
+
+  def init({type, opts, index, trigger, acc, reducer}) do
+    Process.flag(:trap_exit, true)
+
+    {on_init, opts} = Keyword.pop(opts, :on_init, & &1)
+    on_init.(index)
+
+    {type, {%{}, build_status(type, trigger), index, acc.(), reducer}, opts}
+  end
+
+  def handle_subscribe(:producer, opts, {pid, ref}, {producers, status, index, acc, reducer}) do
+    opts[:tag] && Process.put(ref, opts[:tag])
+    status = producer_status(pid, ref, status)
+    state = {Map.put(producers, ref, nil), status, index, acc, reducer}
+
+    if status.done? do
+      GenStage.cancel({pid, ref}, :normal, [:noconnect])
+      {:manual, state}
+    else
+      {:automatic, state}
+    end
+  end
+
+  def handle_subscribe(:consumer, _, _, state) do
+    {:automatic, state}
+  end
+
+  def handle_cancel(_, {_, ref}, {producers, status, index, acc, reducer}) do
+    case producers do
+      %{^ref => _} ->
+        Process.delete(ref)
+        {events, acc, status} = done_status(status, index, acc, ref)
+        {:noreply, events, {Map.delete(producers, ref), status, index, acc, reducer}}
+
+      _ ->
+        {:noreply, [], {producers, status, index, acc, reducer}}
+    end
+  end
+
+  def handle_info({:trigger, name}, {producers, status, index, acc, reducer}) do
+    %{trigger: trigger} = status
+    {events, acc} = trigger.(acc, index, name)
+    {:noreply, events, {producers, status, index, acc, reducer}}
+  end
+
+  def handle_info(:stop, state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, [], state}
+  end
+
+  def handle_events(events, {_, ref}, {producers, status, index, acc, reducer})
+      when is_function(reducer, 4) do
+    {events, acc} = reducer.(ref, events, acc, index)
+    {:noreply, events, {producers, status, index, acc, reducer}}
+  end
+
+  def handle_events(events, {_, ref}, {producers, status, index, acc, reducer}) do
+    {producers, events, acc} = reducer.(producers, ref, events, acc, index)
+    {:noreply, events, {producers, status, index, acc, reducer}}
+  end
+
+  ## Helpers
+
+  defp build_status(_type, trigger) do
+    %{producers: %{}, done?: false, trigger: trigger}
+  end
+
+  defp producer_status(pid, ref, %{producers: producers} = status) do
+    %{status | producers: Map.put(producers, ref, pid)}
+  end
+
+  defp done_status(%{producers: map, done?: true} = status, _index, acc, _ref) when map == %{} do
+    {[], acc, status}
+  end
+
+  defp done_status(%{done?: false} = status, index, acc, ref) do
+    %{trigger: trigger, producers: producers} = status
+
+    case Map.delete(producers, ref) do
+      new_producers when new_producers == %{} and producers != %{} ->
+        {events, acc} = trigger.(acc, index, :done)
+        GenStage.async_info(self(), :stop)
+        {events, acc, %{status | producers: %{}, done?: true}}
+
+      producers ->
+        {[], acc, %{status | producers: producers}}
+    end
+  end
+end


### PR DESCRIPTION
Hello!
This is a PR that adds the following features:

- No screen flicker on save
- Move cursor on format error
- Format through STDIN
- Status messages

I tried to stick to the original principles and keep the plugin slim, so no settings are provided yet, although I was considering adding one for the "move cursor" functionality.

## No screen flicker on save

When file is saved, there is no "screen flicker" (file refresh), text is replaced through sublime instead of using `mix format` to overwrite the file system: it uses pipes to get output from `mix format`.
This allows for a better user experience where as soon as the user saves, it can keep typing and do work, since the text replacement is an integrated experience.

## Move cursor on format error

Emulating `JsPrettier`, when the file is saved and there is an error, the cursor will move to the line causing the error. A status message is presented in the bottom status bar showing the mix format error along with the exception name

## Format through STDIN

`mix format` is now getting the file through STDIN and outputting the result to STDOUT, this allows for a better integration with python and can potentially provide further refactor capabilities, such as formatting only a selection or formatting text within non-elixir files (e.g. markdown)

## Status messages

As mentioned earlier, on error a status message is displayed. One is also displayed in case of save with successful formatting, however none is displayed if save is successful but no formatting happened (file is already formatted)